### PR TITLE
Remove redundant method `Resolve()`

### DIFF
--- a/SimpleContainer.Unity/Assets/SimpleContainer.Unity/Installers/MonoInstaller.cs
+++ b/SimpleContainer.Unity/Assets/SimpleContainer.Unity/Installers/MonoInstaller.cs
@@ -10,8 +10,6 @@ namespace SimpleContainer.Unity.Installers
     {
         public abstract void Install(Container container);
 
-        public virtual void Resolve(Container container) { }
-
         public virtual Task ResolveAsync(Container container)
         {
             return Task.CompletedTask;

--- a/SimpleContainer.Unity/Assets/SimpleContainer.Unity/Installers/MonoInstaller.cs
+++ b/SimpleContainer.Unity/Assets/SimpleContainer.Unity/Installers/MonoInstaller.cs
@@ -6,15 +6,31 @@ using UnityEngine;
 
 namespace SimpleContainer.Unity.Installers
 {
+    /// <summary>
+    /// Unity-specific implementation of installer.
+    /// Contains methods for running a composition root.
+    /// </summary>
     public abstract class MonoInstaller : MonoBehaviour, IInstaller
     {
+        /// <summary>
+        /// Registers contract/result types and instances.
+        /// </summary>
         public abstract void Install(Container container);
 
+        /// <summary>
+        /// Method for non-lazy resolvings calls.
+        /// May be required to avoid <see cref="Exceptions.TypeNotRegisteredException"/>
+        /// at <see cref="Container.ThrowIfNotResolved()"/>
+        /// in situations when contract dependency was not declared.
+        /// </summary>
         public virtual Task ResolveAsync(Container container)
         {
             return Task.CompletedTask;
         }
 
+        /// <summary>
+        /// The point where all resolvings at <see cref="UnityProjectRoot.Awake()"/> is guaranteed.
+        /// </summary>
         public virtual Task AfterResolveAsync(Container container)
         {
             return Task.CompletedTask;


### PR DESCRIPTION
# Proposed changes
* Remove redundant `MonoInstaller.Resolve()` method

# References
Closes #2  